### PR TITLE
Fix window resize making app unusable

### DIFF
--- a/env/player.py
+++ b/env/player.py
@@ -11,7 +11,7 @@ from utils.camera_animation_stack import CameraAnimation, CameraAnimationStack
 class Player:
     """Manages player camera and input handling."""
 
-    NAVIGATION_DURATION = 0.5   # seconds for folder-enter transitions
+    NAVIGATION_DURATION = 0.5
 
     def __init__(self, config, fullscreen_toggle=None):
         self.config = config
@@ -66,8 +66,7 @@ class Player:
         self.animation_stack.clear()
         self.animation_stack.push(anim)
 
-    def update(self, dt):
-        # Advance any active animation and apply its state to the camera.
+    def update(self, dt, win_w=None, win_h=None):
         result = self.animation_stack.update(dt)
         if result is not None:
             pos, yaw, pitch = result
@@ -76,8 +75,11 @@ class Player:
             self.camera.pitch = pitch
 
         if not pygame.mouse.get_visible():
-            cx = pygame.display.get_surface().get_width() // 2
-            cy = pygame.display.get_surface().get_height() // 2
+            if win_w is not None and win_h is not None:
+                cx, cy = win_w // 2, win_h // 2
+            else:
+                surf = pygame.display.get_surface()
+                cx, cy = surf.get_width() // 2, surf.get_height() // 2
 
             if not self.animation_stack.is_animating():
                 keys = pygame.key.get_pressed()
@@ -92,7 +94,6 @@ class Player:
                 if up:
                     self.camera.y += up * speed
 
-            # Keep cursor centred so mouse-look has no jump when control returns.
             pygame.mouse.set_pos(cx, cy)
 
     def apply_look(self):

--- a/main.py
+++ b/main.py
@@ -29,6 +29,8 @@ if __name__ == "__main__":
     world.config = config
 
     win_w, win_h = EngineInitializer.InitializeOpenGLWindow(config)
+    _surf = pygame.display.get_surface()
+    win_w, win_h = _surf.get_width(), _surf.get_height()
 
     # Load initial directory
     world.load_directory(root_folder)
@@ -54,7 +56,7 @@ if __name__ == "__main__":
             config.set('window_height', logical_h)
             config.save()
 
-        player.update(dt)
+        player.update(dt, win_w, win_h)
         world.update()
 
         # Rendering
@@ -81,4 +83,3 @@ if __name__ == "__main__":
         pygame.display.flip()
 
     pygame.quit()
-    

--- a/utils/interaction_handler.py
+++ b/utils/interaction_handler.py
@@ -25,7 +25,13 @@ class InteractionHandler:
     
     @staticmethod
     def ResizeWindow(newWidth, newHeight):
+        newWidth  = max(newWidth,  200)
+        newHeight = max(newHeight, 150)
         pygame.display.set_mode((newWidth, newHeight), DOUBLEBUF | OPENGL | RESIZABLE)
+        if not pygame.mouse.get_visible():
+            pygame.event.set_grab(True)
+            cx, cy = newWidth // 2, newHeight // 2
+            pygame.mouse.set_pos(cx, cy)
 
     @staticmethod
     def GetRay(mouse_x, mouse_y):
@@ -42,4 +48,3 @@ class InteractionHandler:
             return ray_o, (ray_d / norm if norm > 0 else ray_d)
         except:
             return np.array([0,0,0]), np.array([0,0,-1])
-        

--- a/utils/renderer.py
+++ b/utils/renderer.py
@@ -48,9 +48,8 @@ class Renderer:
         for event in events:
             if event.type == VIDEORESIZE:
                 InteractionHandler.ResizeWindow(*event.size)
-                glViewport(0, 0, event.size[0], event.size[1])
-                viewport = glGetIntegerv(GL_VIEWPORT)
-                return int(viewport[2]), int(viewport[3])
+                surf = pygame.display.get_surface()
+                return surf.get_width(), surf.get_height()
         return None
 
     @staticmethod


### PR DESCRIPTION
Closes #33

## Summary
- `ResizeWindow` now clamps minimum window size to 200×150 and re-centres the cursor after resize so mouse-look doesn't jump
- `Renderer.handle_events` reads the new surface dimensions from `pygame` instead of querying the GL viewport (fixes mismatch on HiDPI displays)
- `player.update()` accepts optional `win_w`/`win_h` so main loop can pass logical dimensions directly, avoiding redundant `get_surface()` calls per frame
- `main.py` re-reads surface size immediately after window init to guarantee `win_w`/`win_h` match the actual display surface

## Test plan
- [ ] Drag window to a very small size — app should stay responsive, not freeze or crash
- [ ] Resize window while in first-person mode — crosshair should stay centred, no mouse-look jump
- [ ] Resize window while cursor is visible (menu mode) — should work normally
- [ ] Verify `win_w`/`win_h` reported in HUD match actual window size after resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)